### PR TITLE
Fix invalid manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,7 @@
     "main": "main.js",
     "scripts": {
         "setup": "scripts/setup.js",
-        "teardown": "scripts/teardown.js",
-        "postback" : "scripts/postback.js"
+        "teardown": "scripts/teardown.js"
     },
     "configuration": {
       "postback": {


### PR DESCRIPTION
With ArangoDB 3.2 the manifest validation during service install throws an error